### PR TITLE
规避煎蛋的反爬虫检查

### DIFF
--- a/jandan_spider.py
+++ b/jandan_spider.py
@@ -2,12 +2,12 @@ import requests
 from bs4 import BeautifulSoup
 
 index = 0
-
+headers={'referer':'http://jandan.net/', 'user-agent':'Mozilla/5.0 (Windows NT 10.0; WOW64; rv:47.0) Gecko/20100101 Firefox/47.0'}
 
 # 保存图片
 def save_jpg(res_url):
     global index
-    html = BeautifulSoup(requests.get(res_url).text)
+    html = BeautifulSoup(requests.get(res_url, headers=headers).text)
     for link in html.find_all('a', {'class': 'view_img_link'}):
         with open('{}.{}'.format(index, link.get('href')[len(link.get('href'))-3: len(link.get('href'))]), 'wb') as jpg:
             jpg.write(requests.get(link.get('href')).content)
@@ -19,4 +19,4 @@ if __name__ == '__main__':
     url = 'http://jandan.net/ooxx'
     for i in range(0, 5):
         save_jpg(url)
-        url = BeautifulSoup(requests.get(url).text).find('a', {'class': 'previous-comment-page'}).get('href')
+        url = BeautifulSoup(requests.get(url, headers=headers).text).find('a', {'class': 'previous-comment-page'}).get('href')


### PR DESCRIPTION
为 http 请求加入必要的头信息，规避煎蛋的反爬虫检查，修复 #1 的问题。
